### PR TITLE
feat: add autoApplyPlaylistNavigation option to MediaSession

### DIFF
--- a/lib/src/models/media_session.dart
+++ b/lib/src/models/media_session.dart
@@ -116,6 +116,15 @@ class MediaSession {
   /// surface (CarPlay, lockscreen, Control Center).
   final List<double> supportedPlaybackRates;
 
+  /// Whether the package automatically calls [Player.next] and [Player.previous]
+  /// when the active playlist has multiple items and the OS issues a
+  /// next/previous track command.
+  ///
+  /// Defaults to `true`. Set to `false` if the application wants to intercept
+  /// and handle next/previous track commands manually (e.g. for custom skip
+  /// behavior, seeking, or server-driven playlists).
+  final bool autoApplyPlaylistNavigation;
+
   // ── App identity ───────────────────────────────────────────────────
 
   /// Display name shown by MPRIS (Linux) and SMTC (Windows) for the
@@ -153,6 +162,7 @@ class MediaSession {
     this.fastForwardInterval = const Duration(seconds: 15),
     this.rewindInterval = const Duration(seconds: 15),
     this.supportedPlaybackRates = const [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
+    this.autoApplyPlaylistNavigation = true,
     this.appName,
     this.desktopEntry,
   });
@@ -176,6 +186,7 @@ class MediaSession {
     Duration? fastForwardInterval,
     Duration? rewindInterval,
     List<double>? supportedPlaybackRates,
+    bool? autoApplyPlaylistNavigation,
     Object? appName = unset,
     Object? desktopEntry = unset,
   }) =>
@@ -193,6 +204,8 @@ class MediaSession {
         rewindInterval: rewindInterval ?? this.rewindInterval,
         supportedPlaybackRates:
             supportedPlaybackRates ?? this.supportedPlaybackRates,
+        autoApplyPlaylistNavigation:
+            autoApplyPlaylistNavigation ?? this.autoApplyPlaylistNavigation,
         appName: identical(appName, unset) ? this.appName : appName as String?,
         desktopEntry: identical(desktopEntry, unset)
             ? this.desktopEntry
@@ -212,6 +225,7 @@ class MediaSession {
         other.interruptionPolicy != interruptionPolicy ||
         other.fastForwardInterval != fastForwardInterval ||
         other.rewindInterval != rewindInterval ||
+        other.autoApplyPlaylistNavigation != autoApplyPlaylistNavigation ||
         other.appName != appName ||
         other.desktopEntry != desktopEntry) {
       return false;
@@ -241,6 +255,7 @@ class MediaSession {
         fastForwardInterval,
         rewindInterval,
         Object.hashAll(supportedPlaybackRates),
+        autoApplyPlaylistNavigation,
         appName,
         desktopEntry,
       );
@@ -253,6 +268,7 @@ class MediaSession {
       'fastForwardInterval: $fastForwardInterval, '
       'rewindInterval: $rewindInterval, '
       'supportedPlaybackRates: $supportedPlaybackRates, '
+      'autoApplyPlaylistNavigation: $autoApplyPlaylistNavigation, '
       'appName: $appName, desktopEntry: $desktopEntry)';
 }
 

--- a/lib/src/player/player_media_session.part.dart
+++ b/lib/src/player/player_media_session.part.dart
@@ -120,11 +120,13 @@ mixin _MediaSessionModule on _PlayerBase {
       case MediaSessionCommandStop():
         unawaited((this as Player).stop());
       case MediaSessionCommandNext():
-        if (_state.playlist.items.length > 1) {
+        if ((_state.mediaSession?.autoApplyPlaylistNavigation ?? true) &&
+            _state.playlist.items.length > 1) {
           unawaited((this as Player).next());
         }
       case MediaSessionCommandPrevious():
-        if (_state.playlist.items.length > 1) {
+        if ((_state.mediaSession?.autoApplyPlaylistNavigation ?? true) &&
+            _state.playlist.items.length > 1) {
           unawaited((this as Player).previous());
         }
       case MediaSessionCommandLike():

--- a/test/models/media_session_test.dart
+++ b/test/models/media_session_test.dart
@@ -46,5 +46,19 @@ void main() {
       expect(a, b);
       expect(a.hashCode, b.hashCode);
     });
+
+    test('autoApplyPlaylistNavigation participates in equality and copyWith', () {
+      const a = MediaSession(autoApplyPlaylistNavigation: true);
+      const b = MediaSession(autoApplyPlaylistNavigation: false);
+
+      expect(a.autoApplyPlaylistNavigation, isTrue);
+      expect(b.autoApplyPlaylistNavigation, isFalse);
+      expect(a, isNot(b));
+      expect(a.hashCode, isNot(b.hashCode));
+
+      final copied = a.copyWith(autoApplyPlaylistNavigation: false);
+      expect(copied.autoApplyPlaylistNavigation, isFalse);
+      expect(copied, b);
+    });
   });
 }


### PR DESCRIPTION
### Description

This PR introduces the `autoApplyPlaylistNavigation` option to the `MediaSession` configuration (defaulting to `true` for full backward compatibility). 

### The Problem
When the FFI player playlist has more than one item (e.g., a multi-file audiobook where each chapter is a separate file), the native OS `MediaSessionCommandNext` and `MediaSessionCommandPrevious` events (from CarPlay, Lock Screen, or headset buttons) are automatically intercepted and routed to `Player.next()` and `Player.previous()` internally by the package.

If a developer wants to customize the behavior of the Next/Previous buttons—for example, mapping them to perform relative seeks (e.g. skip +30s / -10s for podcast/audiobook skip button styles) instead of changing playlist tracks—they encounter a conflict: the package changes the track *and* the application tries to seek concurrently, resulting in unintended chapter skips and double-firing actions.

### The Solution
By adding `autoApplyPlaylistNavigation` to `MediaSession`:
* When `true` (default): maintains the smart-default behavior of automatically calling `Player.next()` / `previous()`.
* When `false`: bypasses the package's automatic playlist track advancement, letting the consuming application listen to `Player.stream.mediaSessionCommands` and custom-handle next/previous events (e.g., executing relative seeks, fetching the next song dynamically from a server, or managing an external playlist queue).

### Changes
1. **`lib/src/models/media_session.dart`**:
   * Added `autoApplyPlaylistNavigation` property (defaults to `true`).
   * Updated `copyWith`, equality (`==`), `hashCode`, and `toString` methods.
2. **`lib/src/player/player_media_session.part.dart`**:
   * Updated `_handleSessionCommand` to only auto-apply `Player.next()` / `previous()` when `autoApplyPlaylistNavigation` is `true`.
3. **`test/models/media_session_test.dart`**:
   * Added unit tests to verify default value, copyWith behavior, and equality of the new configuration field.
